### PR TITLE
updating AST visitors API in DASTInterpreter and DASTPostOrderTreeVisitor

### DIFF
--- a/DebuggableASTInterpreter/DASTInterpreter.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreter.class.st
@@ -311,6 +311,12 @@ DASTInterpreter >> visitArgumentNode: aRBArgumentNode [
 ]
 
 { #category : #visiting }
+DASTInterpreter >> visitArgumentVariableNode: aRBVariableNode [
+
+	^ self visitTemporaryNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 DASTInterpreter >> visitArrayNode: aRBArrayNode [ 
 	| literals size arrayMirror |
 	size := aRBArrayNode statements size.
@@ -343,10 +349,22 @@ DASTInterpreter >> visitCascadeNode: aRBCascadeNode [
 ]
 
 { #category : #visiting }
+DASTInterpreter >> visitClassVariableNode: aRBVariableNode [
+
+	^ self visitGlobalNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 DASTInterpreter >> visitGlobalNode: aRBGlobalNode [ 
 
 	self stackPush: (currentContext findVariable: aRBGlobalNode name)
 	
+]
+
+{ #category : #visiting }
+DASTInterpreter >> visitGlobalVariableNode: aRBVariableNode [
+
+	^ self visitGlobalNode: aRBVariableNode
 ]
 
 { #category : #visiting }
@@ -462,6 +480,12 @@ DASTInterpreter >> visitTemporaryNode: aRBTemporaryNode [
 	aRBTemporaryNode isDefinition 
 		ifTrue: [ currentContext at: name put: self evaluator nilObject ]
 		ifFalse: [ self stackPush: (currentContext findVariable: name)]
+]
+
+{ #category : #visiting }
+DASTInterpreter >> visitTemporaryVariableNode: aRBVariableNode [
+
+	^ self visitTemporaryNode: aRBVariableNode
 ]
 
 { #category : #visiting }

--- a/DebuggableASTInterpreter/DASTPostOrderTreeVisitor.class.st
+++ b/DebuggableASTInterpreter/DASTPostOrderTreeVisitor.class.st
@@ -38,6 +38,12 @@ DASTPostOrderTreeVisitor >> visitArgumentNode: aRBArgumentNode [
 ]
 
 { #category : #visiting }
+DASTPostOrderTreeVisitor >> visitArgumentVariableNode: aRBVariableNode [
+
+	^ self visitTemporaryNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 DASTPostOrderTreeVisitor >> visitArrayNode: aRBArrayNode [ 
 	stack push: aRBArrayNode.
 	aRBArrayNode children reverse do: [ :e | e acceptVisitor: self ].	
@@ -62,8 +68,20 @@ DASTPostOrderTreeVisitor >> visitCascadeNode: aRBCascadeNode [
 ]
 
 { #category : #visiting }
+DASTPostOrderTreeVisitor >> visitClassVariableNode: aRBVariableNode [
+
+	^ self visitGlobalNode: aRBVariableNode
+]
+
+{ #category : #visiting }
 DASTPostOrderTreeVisitor >> visitGlobalNode: aRBGlobalNode [ 
 	stack push: aRBGlobalNode
+]
+
+{ #category : #visiting }
+DASTPostOrderTreeVisitor >> visitGlobalVariableNode: aRBVariableNode [
+
+	^ self visitGlobalNode: aRBVariableNode
 ]
 
 { #category : #visiting }
@@ -136,6 +154,12 @@ DASTPostOrderTreeVisitor >> visitSuperNode: aRBSuperNode [
 { #category : #'as yet unclassified' }
 DASTPostOrderTreeVisitor >> visitTemporaryNode: aRBTemporaryNode [ 
 	stack push: aRBTemporaryNode
+]
+
+{ #category : #visiting }
+DASTPostOrderTreeVisitor >> visitTemporaryVariableNode: aRBVariableNode [
+
+	^ self visitTemporaryNode: aRBVariableNode
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
The AST visitors API has changed so it should be updated in `DASTInterpreter` and `DASTPostOrderTreeVisitor`.

To do that, in both classes, I implemented:

- `visitTemporaryVariableNode:` that calls `visitTemporaryNode:` for retrocompatability
- `visitArgumentVariableNode:` that calls `visitTemporaryNode:` for retrocompatibility
- `visitClassVariableNode:` that calls `visitGlobalNode:`for retrocompatibility
- `visitGlobalVariableNode:` that calls `visitGlobalNode:`for retrocompatibility