### PR TITLE
Fixing tests because of changes in AST variable nodes, as `RBGlobalNode` doesn't exist anymore

### DIFF
--- a/DebuggableASTInterpreter/DASTInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreterTests.class.st
@@ -220,7 +220,7 @@ DASTInterpreterTests >> testExecutedNodesAfterStepInto [
 	interpreter stepInto.
 	self
 		assert: interpreter currentContext executedNodes
-		equals: (DASTStack new push: (RBGlobalNode named: #Point); yourself)
+		equals: (DASTStack new push: (RBVariableNode named: #Point); yourself)
 ]
 
 { #category : #'tests-contexts' }
@@ -228,7 +228,7 @@ DASTInterpreterTests >> testExecutedNodesAfterStepOver [
 	| expectedStack |
 	self initializeProgram: '^Point x: 1 y: 2'.
 	expectedStack := DASTStack new.
-	expectedStack push: (RBGlobalNode named: #Point).
+	expectedStack push: (RBVariableNode named: #Point).
 	expectedStack push: (RBLiteralValueNode value: 1).
 	expectedStack push: (RBLiteralValueNode value: 2).
 	interpreter stepOver.


### PR DESCRIPTION
Fixes #9 

Two tests were red because they were using `RBGlobalNode` but that class disappeared. Indeed, all variable scopes used to be represented with different subclasses but now, all variables are represented in the AST with `RBVariableNode` and the scopes of these variables is now represented with a property of the variable node.

So, I fixed these tests by using `RBVariableNode` instead of `RBGlobalNode`