### PR TITLE
Fixing valueToBlock method

### DIFF
--- a/DebuggableASTInterpreter/DASTContext.class.st
+++ b/DebuggableASTInterpreter/DASTContext.class.st
@@ -56,7 +56,7 @@ DASTContext class >> newWithSender: aDASTContext receiver: aReceiver messageNode
 	| context |
 	context := ((aDASTEvaluator isEPDASTBlockMirror: aReceiver ) 
 					and: [ " Check if the message is one of the variants of value. This is very ugly and must be changed when implementing environments "
-						self valueToBlockMessages keys includes: aRBMessageNode selector ])
+						self valueToBlockMessages includes: aRBMessageNode selector ])
 		ifTrue: [ DASTBlockContext new ]
 		ifFalse: [ DASTMethodContext new ].
 	context sender: aDASTContext;
@@ -68,8 +68,17 @@ DASTContext class >> newWithSender: aDASTContext receiver: aReceiver messageNode
 
 { #category : #'instance creation' }
 DASTContext class >> valueToBlockMessages [
-	^ valueToBlockMessages 
-		ifNil: [ valueToBlockMessages := (BlockClosure methodDict select: [ :e | (201 to: 206) includes: e primitive ]) collect: [ :e | e selector ] ]
+
+	^ valueToBlockMessages ifNil: [ 
+		  valueToBlockMessages := (BlockClosure methodDict select: [ :e | "Is it really better than `(205 to: 209) includes: e primitive` ?"
+			                           #( #value #value: #value:value:
+			                              #value:value:value:
+			                              #value:value:value:value:
+			                              #value #value:value: #value:value:
+			                              #valueNoContextSwitch
+			                              valueNoContextSwitch:
+			                              #valueWithArguments ) includes:
+				                           e selector ]) keys ]
 ]
 
 { #category : #'accessing variables' }

--- a/DebuggableASTInterpreter/DASTContext.class.st
+++ b/DebuggableASTInterpreter/DASTContext.class.st
@@ -70,15 +70,12 @@ DASTContext class >> newWithSender: aDASTContext receiver: aReceiver messageNode
 DASTContext class >> valueToBlockMessages [
 
 	^ valueToBlockMessages ifNil: [ 
-		  valueToBlockMessages := (BlockClosure methodDict select: [ :e | "Is it really better than `(205 to: 209) includes: e primitive` ?"
-			                           #( #value #value: #value:value:
-			                              #value:value:value:
-			                              #value:value:value:value:
-			                              #value #value:value: #value:value:
-			                              #valueNoContextSwitch
-			                              valueNoContextSwitch:
-			                              #valueWithArguments ) includes:
-				                           e selector ]) keys ]
+		  valueToBlockMessages := #( #value #value: #value:value:
+		                             #value:value:value: #value:value:value:value:
+		                             #value #value:value: #value:value:
+		                             #valueNoContextSwitch
+		                             valueNoContextSwitch:
+		                             #valueWithArguments ) ]
 ]
 
 { #category : #'accessing variables' }


### PR DESCRIPTION
Fixes #8

`DASTContext class>>#valueToBlock` used a `collect:` expression on a MethodDictionary, that returns a MethodDictionary which  should contain compiled methods as values but which contain selectors instead. This was producing a DNU.

As its senders of this method were only using method selectors, I fixed it so that it returns only an array  of selectors instead of a method dictionary.

Furthermore, this method should return the selector that use primitives that enter blocks (i.e: `#value` and its variants). However, the IDs of these primitives have changed, which were used by this method. So, instead of updating the IDs of these primitives in this method, I refactored the method so that it checks the selector of the methods that use this primitive instead, as these selectors are less likely to change in the future 