### PR TITLE
Adding semantic analysis when a context is set on a method or block

### DIFF
--- a/DebuggableASTInterpreter/DASTClosure.class.st
+++ b/DebuggableASTInterpreter/DASTClosure.class.st
@@ -37,7 +37,7 @@ DASTClosure >> body [
 { #category : #testing }
 DASTClosure >> doSemanticAnalysis [
 
-	^ nodeAST 
+	^ nodeAST doSemanticAnalysis
 ]
 
 { #category : #initialization }

--- a/DebuggableASTInterpreter/DASTClosure.class.st
+++ b/DebuggableASTInterpreter/DASTClosure.class.st
@@ -41,12 +41,13 @@ DASTClosure >> doSemanticAnalysis [
 ]
 
 { #category : #initialization }
-DASTClosure >> initializeWith: aRBNode [ 
-	
+DASTClosure >> initializeWith: aRBNode [
+
 	sourceCode := aRBNode sourceCode.
 	nodeAST := aRBNode.
-	numArgs := nodeAST arguments size
-	
+	numArgs := nodeAST arguments size.
+
+	nodeAST doSemanticAnalysis
 ]
 
 { #category : #accessing }
@@ -81,8 +82,10 @@ DASTClosure >> nodeAST [
 ]
 
 { #category : #accessing }
-DASTClosure >> nodeAST: aRBNode [ 
-	nodeAST := aRBNode
+DASTClosure >> nodeAST: aRBNode [
+
+	nodeAST := aRBNode.
+	nodeAST doSemanticAnalysis
 ]
 
 { #category : #accessing }

--- a/DebuggableASTInterpreter/DASTClosure.class.st
+++ b/DebuggableASTInterpreter/DASTClosure.class.st
@@ -37,11 +37,7 @@ DASTClosure >> body [
 { #category : #initialization }
 DASTClosure >> initializeWith: aRBNode [
 
-	sourceCode := aRBNode sourceCode.
-	nodeAST := aRBNode.
-	numArgs := nodeAST arguments size.
-
-	nodeAST doSemanticAnalysis
+	self nodeAST: aRBNode
 ]
 
 { #category : #accessing }
@@ -78,7 +74,10 @@ DASTClosure >> nodeAST [
 { #category : #accessing }
 DASTClosure >> nodeAST: aRBNode [
 
+	sourceCode := aRBNode sourceCode.
 	nodeAST := aRBNode.
+	numArgs := nodeAST arguments size.
+
 	nodeAST doSemanticAnalysis
 ]
 

--- a/DebuggableASTInterpreter/DASTClosure.class.st
+++ b/DebuggableASTInterpreter/DASTClosure.class.st
@@ -34,12 +34,6 @@ DASTClosure >> body [
 	^ nodeAST body
 ]
 
-{ #category : #testing }
-DASTClosure >> doSemanticAnalysis [
-
-	^ nodeAST doSemanticAnalysis
-]
-
 { #category : #initialization }
 DASTClosure >> initializeWith: aRBNode [
 

--- a/DebuggableASTInterpreter/DASTContext.class.st
+++ b/DebuggableASTInterpreter/DASTContext.class.st
@@ -522,8 +522,7 @@ DASTContext >> methodOrBlock [
 { #category : #accessing }
 DASTContext >> methodOrBlock: aDASTClosure [
 
-	closure := aDASTClosure.
-	closure doSemanticAnalysis
+	closure := aDASTClosure
 ]
 
 { #category : #'private-exceptions' }

--- a/DebuggableASTInterpreter/DASTContext.class.st
+++ b/DebuggableASTInterpreter/DASTContext.class.st
@@ -522,7 +522,8 @@ DASTContext >> methodOrBlock [
 { #category : #accessing }
 DASTContext >> methodOrBlock: aDASTClosure [
 
-	closure := aDASTClosure
+	closure := aDASTClosure.
+	closure doSemanticAnalysis
 ]
 
 { #category : #'private-exceptions' }


### PR DESCRIPTION
The interpreter evaluated a program that is never checked by a semantic analyser.

As a result, variables don't know their scope, and its not possible lookup for these unresolved variables in a context.

To fix that, a context now ask their new method/closure to do their semantic analysis each time it changes its method/closure