### PR TITLE
Testing program termination with evaluation instead of steps

### DIFF
--- a/DebuggableASTInterpreter/DASTDebuggerInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTDebuggerInterpreterTests.class.st
@@ -17,6 +17,7 @@ DASTDebuggerInterpreterTests >> testStepAfterTheEndOfProgramExcecutionThrowsAnEx
 
 	interpreter initializeWithProgram: (RBParser parseExpression: '1').
 
+	"Initializing a program creates a noMethod with body '^ 1' so evaluating the program performs 2 steps over: one to step over the 1 literal value node and one to step over the return node "
 	interpreter evaluate.
 
 	self should: [ interpreter stepOver ] raise: DASTEvaluationTerminated

--- a/DebuggableASTInterpreter/DASTDebuggerInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTDebuggerInterpreterTests.class.st
@@ -14,11 +14,12 @@ DASTDebuggerInterpreterTests >> testFirstNodeToEvaluateInASum [
 
 { #category : #tests }
 DASTDebuggerInterpreterTests >> testStepAfterTheEndOfProgramExcecutionThrowsAnException [
+
 	interpreter initializeWithProgram: (RBParser parseExpression: '1').
-	self assert: (interpreter stepOver; stackTop) equals: 1.
-	self should: [interpreter stepOver; stackTop] raise: DASTEvaluationTerminated 
-	
-	
+
+	interpreter evaluate.
+
+	self should: [ interpreter stepOver ] raise: DASTEvaluationTerminated
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fixes #14 

This test asserts that any step after performing a single test will raise an exception because the evaluated program is composed of only one literal value node.

However this is not true as the interpreter creates a context with a return node for a program with no method node.

As this is tricky and we don't test here the number of steps we need to perform before a program is terminated, I refactored the test so that any step that is performed after the program evaluation raises an exception