### PR TITLE
fixing non-local returns by raising an error if the home context of a block  is dead

### DIFF
--- a/DebuggableASTInterpreter/DASTContext.class.st
+++ b/DebuggableASTInterpreter/DASTContext.class.st
@@ -19,7 +19,8 @@ Class {
 		'tempVarIndex',
 		'tempVarsNamesIndexes',
 		'unhandledException',
-		'evaluator'
+		'evaluator',
+		'isDead'
 	],
 	#classVars : [
 		'valueToBlockMessages'
@@ -441,6 +442,18 @@ DASTContext >> isCurrentContext [
 ]
 
 { #category : #testing }
+DASTContext >> isDead [
+
+	^ isDead ifNil: [ isDead := false ]
+]
+
+{ #category : #accessing }
+DASTContext >> isDead: aBool [
+
+	isDead := aBool
+]
+
+{ #category : #testing }
 DASTContext >> isEmpty [
 	
 	^ variablesDict isEmpty.
@@ -512,6 +525,14 @@ DASTContext >> messageNode: aRBMessageNode [
 { #category : #accessing }
 DASTContext >> methodClass [
 	^ self methodOrBlock methodClass
+]
+
+{ #category : #accessing }
+DASTContext >> methodContext [
+
+	^ self isBlockContext
+		  ifTrue: [ self parent methodContext ]
+		  ifFalse: [ self ]
 ]
 
 { #category : #accessing }

--- a/DebuggableASTInterpreter/DASTInterpreter.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreter.class.st
@@ -19,6 +19,12 @@ DASTInterpreter >> astCache: aCollection [
 	astCache := aCollection
 ]
 
+{ #category : #private }
+DASTInterpreter >> cannotReturn: value to: homeContext [
+
+	^ BlockCannotReturn result: value from: homeContext
+]
+
 { #category : #accessing }
 DASTInterpreter >> context [
 	self shouldBeImplemented.
@@ -440,11 +446,17 @@ DASTInterpreter >> visitMethodNode: aRBBlockNode [
 
 { #category : #visiting }
 DASTInterpreter >> visitReturnNode: aRBReturneNode [
-	| value senderContext |
-	
+
+	| value senderContext methodContext |
 	value := currentContext stack top.
-	senderContext := currentContext returnContext. 
-	
+	senderContext := currentContext returnContext.
+	methodContext := self currentContext methodContext.
+
+	(self currentContext isBlockContext and: [ methodContext isDead ]) 
+		ifTrue: [ self cannotReturn: value to: senderContext ].
+
+	methodContext isDead: true.
+
 	currentContext := senderContext.
 	self stackPush: value
 ]
@@ -456,16 +468,15 @@ DASTInterpreter >> visitSelfNode: aRBSelfNode [
 ]
 
 { #category : #visiting }
-DASTInterpreter >> visitSequenceNode: aRBSequenceNode [ 
-	
+DASTInterpreter >> visitSequenceNode: aRBSequenceNode [
+
 	| lastResult |
-	lastResult := self currentContext isBlockContext 
-		ifTrue: [ self stackPop ]
-		ifFalse: [ self currentContext receiver ].
-	
+	lastResult := self currentContext isBlockContext
+		              ifTrue: [ self stackPop ]
+		              ifFalse: [ self currentContext receiver ].
+	currentContext isDead: true.
 	currentContext := currentContext sender.
-	self stackPush: lastResult. 
-	
+	self stackPush: lastResult
 ]
 
 { #category : #visiting }

--- a/DebuggableASTInterpreter/DASTInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreterTests.class.st
@@ -633,9 +633,11 @@ DASTInterpreterTests >> testMoreThan [
 { #category : #'tests-blocks' }
 DASTInterpreterTests >> testNonLocalReturn [
 
-	self assert: (self evaluateProgram: '(DASTInterpreterClassForTests new getBlockThatReturns32) value' ) 
-		  equals: false
-	
+	self
+		should: [ 
+			self evaluateProgram:
+				'(DASTInterpreterClassForTests new getBlockThatReturns32) value' ]
+		raise: BlockCannotReturn
 ]
 
 { #category : #'tests-exceptions-ondo' }


### PR DESCRIPTION
Fixes #12 

A test was written so that, when the interpreter evaluates a block with a non local return and a dead home context, it returns false. However, such a case in Pharo should raise a BlockCannotReturn error, because the home context has already returned.

I modified the test to check that evaluating such a program raises the error and I fixed it like this:

- When an interpreter visits a return node,  if the current context is a block context and if the home context of this block context is dead, BlockCannotReturn error is raised. Then the home context of the closure (method or block) of the current context is marked as dead
- When an interpreter visits a sequence node (basically, it is visited when no return node has been executed in the context yet), it marks the current context as dead