### PR TITLE
Fixing stepInto so that it pushes the last executed node in a context into the right context's stack

### DIFF
--- a/DebuggableASTInterpreter/DASTInterpreter.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreter.class.st
@@ -263,14 +263,16 @@ DASTInterpreter >> stackTop [
 
 { #category : #evaluation }
 DASTInterpreter >> stepInto [
-	| node |
-	currentContext canExecute
-		ifFalse: [ DASTEvaluationTerminated signal ].
+
+	| node initialContext |
+	initialContext := currentContext.
+	currentContext canExecute ifFalse: [ DASTEvaluationTerminated signal ].
 	node := currentContext nodes pop.
 	currentContext currentNode: node.
 	self visit: node.
 	self increasePC.
-	currentContext executedNodes push: node.
+	"We use initialContext instead of currentContext as currentContext may have changed it a return node or sequence node has been visited"
+	initialContext executedNodes push: node.
 	^ self currentContext
 ]
 

--- a/DebuggableASTInterpreter/DASTInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreterTests.class.st
@@ -787,6 +787,28 @@ DASTInterpreterTests >> testSetInheritedClassVariableFromMethodInInstanceSide [
 
 ]
 
+{ #category : #'tests-blocks' }
+DASTInterpreterTests >> testSteppingPutsExecutedNodeInStackOfRightContext [
+
+	| currentContext |
+	interpreter initializeWithProgram: (RBParser parseExpression: '^ 1').
+
+	currentContext := interpreter currentContext.
+
+	self assert: currentContext executedNodes isEmpty.
+
+	"steps the 1 literal value node"
+	interpreter stepInto.
+
+	self assert: currentContext executedNodes size equals: 1.
+
+	interpreter stepInto.
+
+	"steps the return node, should be pushed in current context and not sender context"
+
+	self assert: currentContext executedNodes size equals: 2
+]
+
 { #category : #'tests-super' }
 DASTInterpreterTests >> testSuperInsideBlock [
 


### PR DESCRIPTION
Fixes #17 

The last executed node (return node/sequence node) used to be pushed into the sender context's stack.

That is because, when a `stepInto` was performed, it visited the node that would be executed and then it is pushed the node in the current context executed nodes' stack.

However, if the visited node is a return node or a sequence node, then the current context is changed and thus, the node was pushed in another context's stack.

I fixed that by storing the initialContext in a variable, before visiting the node that will be executed. After the node has been visited, it is pushed into the executed nodes's stack of the initialContext