### PR TITLE
Fixing testExecutedNodesAfterExecution that was wrongly tested

### DIFF
--- a/DebuggableASTInterpreter/DASTInterpreter.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreter.class.st
@@ -263,14 +263,16 @@ DASTInterpreter >> stackTop [
 
 { #category : #evaluation }
 DASTInterpreter >> stepInto [
-	| node |
-	currentContext canExecute
-		ifFalse: [ DASTEvaluationTerminated signal ].
+
+	| node initialContext |
+	initialContext := currentContext.
+	currentContext canExecute ifFalse: [ DASTEvaluationTerminated signal ].
 	node := currentContext nodes pop.
 	currentContext currentNode: node.
 	self visit: node.
 	self increasePC.
-	currentContext executedNodes push: node.
+	"We use initialContext instead of currentContext as currentContext may have changed it a return node or sequence node has been visited"
+	initialContext executedNodes push: node.
 	^ self currentContext
 ]
 

--- a/DebuggableASTInterpreter/DASTInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreterTests.class.st
@@ -200,14 +200,22 @@ DASTInterpreterTests >> testExceptionSignalInSequence [
 
 { #category : #'tests-contexts' }
 DASTInterpreterTests >> testExecutedNodesAfterExecution [
+
 	| nodesStackBackup contextBackup |
 	self initializeProgram: 'Point x: 1 y: 2'.
 	contextBackup := interpreter currentContext.
 	nodesStackBackup := contextBackup nodes asArray.
 	interpreter evaluate.
-	self flag: 'That cannot work, as the execution for the #x:y: method "inserts" the body of the method node in the nodes stack'.
+
+	"The sequence node (that is the last node) is not executed as the return node is executed before"
 	self
-		assert: interpreter currentContext executedNodes asArray reversed
+		assertCollection: contextBackup executedNodes asArray reversed
+		equals: nodesStackBackup allButLast.
+
+	"The concatenation of all the executed nodes and all nodes that haven't been executed is equal to all nodes"
+	self
+		assertCollection:
+		(contextBackup nodes , contextBackup executedNodes reversed) asArray
 		equals: nodesStackBackup
 ]
 

--- a/DebuggableASTInterpreter/DASTInterpreterTests.class.st
+++ b/DebuggableASTInterpreter/DASTInterpreterTests.class.st
@@ -787,6 +787,28 @@ DASTInterpreterTests >> testSetInheritedClassVariableFromMethodInInstanceSide [
 
 ]
 
+{ #category : #'tests-blocks' }
+DASTInterpreterTests >> testSteppingPutsExecutedNodeInStackOfRightContext [
+
+	| currentContext |
+	interpreter initializeWithProgram: (RBParser parseExpression: '^ 1').
+
+	currentContext := interpreter currentContext.
+
+	self assert: currentContext executedNodes isEmpty.
+
+	"steps the 1 literal value node"
+	interpreter stepInto.
+
+	self assert: currentContext executedNodes size equals: 1.
+
+	interpreter stepInto.
+
+	"steps the return node, should be pushed in current context and not sender context"
+
+	self assert: currentContext executedNodes size equals: 2
+]
+
 { #category : #'tests-super' }
 DASTInterpreterTests >> testSuperInsideBlock [
 


### PR DESCRIPTION
Fixes #15. Needs #19 to be merged first.

`testExecutedNodesAfterExecution` was red because it was testing that all nodes in a method context were executed. This was not possible as there's at least one node among the sequence node or the return node that is not executed. I fixed that by taking the sequence node that is not executed into account.

Plus, after the program has been evaluated, the test was accessing the executed node of the current context, which is the root context after evaluation instead of the context we're interested in. I fixed that by using the context we have previously stored in a variable instead of currentContext